### PR TITLE
Moving TOC to inline and using named anchors

### DIFF
--- a/app/_elements/notifications.md
+++ b/app/_elements/notifications.md
@@ -6,7 +6,7 @@ tags:
   - alert
   - toast
   - notify
-status: Ready
+status: ready
 ---
 
 Notifications are used to provide feedback brief system messages to the users from the system. They can be used to communicate explicit actions from the user or implicit things that have happened due to a change in the system.

--- a/app/_layouts/page.html
+++ b/app/_layouts/page.html
@@ -14,19 +14,17 @@ layout: default
         <h4>Content for this topic is not created yet but is in our queue for production.</h4>
     </div>
     {% else %}
-    <div id="post-content">{{ content }}</div>
-    {% endcase %}
+    <div id="post-content">
+        <div id="tocTitle">Contents</div>
+        <div id="toc">
+        
+        <ul id="tocList"></ul>
+        </div>{{ content }}</div>
     <p>Last updated on <span id="dateModified">{{ page.last_modified_at | date: '%B %d, %Y' }}</span></p>
     <paper-tooltip for="dateModified">{{ page.last_modified_at | date: '%B %d, %Y, %l:%M:%S %p %Z' }}</paper-tooltip>
 </div>
 
-<!-- Add TOC for ready or WIP pages -->
-{% case page.status %} {% when 'WIP' or "ready" %}
-<div id="toc">
-        <div id="tocTitle">Contents</div>
-        <ul id="tocList">                     
-        </ul>
-</div>    
+   
 <script>
     buildTOC();
 </script>

--- a/app/js/toc.js
+++ b/app/js/toc.js
@@ -6,14 +6,32 @@ function buildTOC(){
         element.parentNode.removeChild(element);
     }else{    
         for (var i = 0; i < h2s.length; i++) {
-                var li = document.createElement("li");
-                var link = document.createElement("a");
+            var li = document.createElement("li");
+            var link = document.createElement("a");
 
-                link.href = "#" + h2s[i].id;;
-                link.innerHTML = h2s[i].innerHTML;
+            link.name = h2s[i].id
+            
+            link.innerHTML = h2s[i].innerHTML;
+            link.addEventListener(
+                "click", 
+                function scrollToAnchor(e) {
+                        e.preventDefault();
+                        var elements = document.getElementsByClassName('content');
+                        var contentElement = elements[0];
 
-                li.appendChild(link);
-                ul.appendChild(li);            
+                        var element = document.getElementById(e.target.name);
+                        var scrollPos = element.offsetTop - 72;
+                        window.scroll({ top: scrollPos, left: 0, behavior: 'smooth' });
+                })
+            li.appendChild(link);
+            ul.appendChild(li);            
+            }
         }
     }
+
+
+function scrollToAnchor(anchor){
+    alert("click");
+    
+
 }

--- a/app/js/toc.js
+++ b/app/js/toc.js
@@ -9,7 +9,7 @@ function buildTOC(){
             var li = document.createElement("li");
             var link = document.createElement("a");
 
-            link.name = h2s[i].id;
+            // link.name = h2s[i].id;
             link.href = "#" + h2s[i].id;
             
             link.innerHTML = h2s[i].innerHTML;

--- a/app/js/toc.js
+++ b/app/js/toc.js
@@ -9,20 +9,21 @@ function buildTOC(){
             var li = document.createElement("li");
             var link = document.createElement("a");
 
-            link.name = h2s[i].id
+            link.name = h2s[i].id;
+            link.href = "#" + h2s[i].id;
             
             link.innerHTML = h2s[i].innerHTML;
-            link.addEventListener(
-                "click", 
-                function scrollToAnchor(e) {
-                        e.preventDefault();
-                        var elements = document.getElementsByClassName('content');
-                        var contentElement = elements[0];
+            // link.addEventListener(
+            //     "click", 
+            //     function scrollToAnchor(e) {
+            //             e.preventDefault();
+            //             var elements = document.getElementsByClassName('content');
+            //             var contentElement = elements[0];
 
-                        var element = document.getElementById(e.target.name);
-                        var scrollPos = element.offsetTop - 72;
-                        window.scroll({ top: scrollPos, left: 0, behavior: 'smooth' });
-                })
+            //             var element = document.getElementById(e.target.name);
+            //             var scrollPos = element.offsetTop - 72;
+            //             window.scroll({ top: scrollPos, left: 0, behavior: 'smooth' });
+            //     })
             li.appendChild(link);
             ul.appendChild(li);            
             }

--- a/app/js/toc.js
+++ b/app/js/toc.js
@@ -9,21 +9,10 @@ function buildTOC(){
             var li = document.createElement("li");
             var link = document.createElement("a");
 
-            // link.name = h2s[i].id;
             link.href = "#" + h2s[i].id;
             
             link.innerHTML = h2s[i].innerHTML;
-            // link.addEventListener(
-            //     "click", 
-            //     function scrollToAnchor(e) {
-            //             e.preventDefault();
-            //             var elements = document.getElementsByClassName('content');
-            //             var contentElement = elements[0];
 
-            //             var element = document.getElementById(e.target.name);
-            //             var scrollPos = element.offsetTop - 72;
-            //             window.scroll({ top: scrollPos, left: 0, behavior: 'smooth' });
-            //     })
             li.appendChild(link);
             ul.appendChild(li);            
             }

--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -282,6 +282,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   #post h2 {
     @apply(--paper-font-headline);
   }
+  #post h2:before {
+    display: block; 
+    content: " "; 
+    margin-top: -75px; 
+    height: 75px; 
+    visibility: hidden;
+  }
 
   #post h3 {
     @apply(--paper-font-title);

--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -652,7 +652,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     padding: 5px;
     text-align: center;
     margin-bottom: 20px;
-    width: 100%;
+    max-width: 900px;
   }
   /* General styles */
 

--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -192,6 +192,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   #tocList a {
     font-weight: 300;
   }
+  #tocList a:hover {
+    cursor: pointer;
+  }
   /* Height of the scroll area */
 
   .content {

--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -68,7 +68,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   html,
   body {
     height: 100%;
-    overflow: hidden;
 
   }
 
@@ -166,7 +165,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     transition: padding 0.2s linear;
     overflow: auto;
     height: auto;
-    margin-bottom: 72px;
+    /* margin-bottom: 72px; */
   }
 
   #post img {
@@ -182,10 +181,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   #tocTitle {
 
-    text-transform: uppercase;
-    font-weight: 500;
-    color: var(--menu-link-color);
-    margin-top: 19px;
+    @apply(--paper-font-headline);
   }
 
   #tocList {
@@ -199,10 +195,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   /* Height of the scroll area */
 
   .content {
-    display: grid;
-    grid-template-columns: 1fr 300px;
-    overflow:hidden;
+    /* display: grid;
+    grid-template-columns: 1fr 300px; */
     height: 100vh;
+    
     /* position: fixed; */
     
   }
@@ -223,9 +219,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       padding-left: 16px;
       padding-right: 16px;
       
-    }
-    #toc {
-      width: 0px;
     }
     .content {
       display: block;

--- a/tasks/ensure-files.js
+++ b/tasks/ensure-files.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var ss = require('smoothscroll-polyfill').polyfill();
 
 /**
  * @param {Array<string>} files


### PR DESCRIPTION
Previous method was buggy across browsers and had to move away from a right column for the TOC, for now. Using named anchors (with pseudo elements) to make it work correctly.