### PR TITLE
fix(travis): remove unnecessary deploy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ script: jekyll build ./_site
 sudo: false # route your build to the container-based infrastructure for a faster build
 
 deploy:
-  edge:
-    branch: v1.8.47
   provider: pages
   skip_cleanup: true
   github_token: $GH_TOKEN


### PR DESCRIPTION
It looks like we pinned the Github Pages deployment tool to a version 1.8.47, to avoid a [temporary breaking change](https://github.com/travis-ci/travis-ci/issues/9312). That was resolved a couple years ago, so removing that [may](https://travis-ci.community/t/github-pages-deploy-failing-on-trusty-dependency-install-error/1528) fix the build issues. 